### PR TITLE
Removing CertificationExamScore from CertificationExam

### DIFF
--- a/Common/CertificationExam.metaed
+++ b/Common/CertificationExam.metaed
@@ -15,9 +15,10 @@ Common CertificationExam
   integer AttemptNumber
     documentation "The attempt number for this exam."
     is optional
-  common CertificationExamScore
-    documentation "A score for a section of a certification exam."
-    is optional collection
+  // Removed pending resolution of ODS-3392
+  // common CertificationExamScore
+  //   documentation "A score for a section of a certification exam."
+  //   is optional collection
   integer CertificationExamOverallScore
     documentation "The overall score that was received on the certification exam."
     is optional


### PR DESCRIPTION
Commenting out part of TPDMX-50 that caused errors in build. Issue tracked by ODS-3392, will leave the common CertificationExamScore metaed file for use when issue is resolved