### PR TITLE
TPDMDEV-274

### DIFF
--- a/DomainEntity/Certification.metaed
+++ b/DomainEntity/Certification.metaed
@@ -6,7 +6,6 @@ Domain Entity Certification
     shared string EdFi.URI named Namespace
         documentation "Namespace for the Certification, typically associated with the issuing authority."
         is part of identity
-        role name Issuer
     shared string CertificationTitle
         documentation "The title of the Certification."
         is required

--- a/DomainEntity/CertificationExam.metaed
+++ b/DomainEntity/CertificationExam.metaed
@@ -6,6 +6,7 @@ Domain Entity CertificationExam
     shared string EdFi.URI named Namespace
         documentation "Namespace for the CertificationExam."
         is part of identity
+        role name Exam
     shared string CertificationExamTitle
         documentation "The title of the Certification Exam."
         is required


### PR DESCRIPTION
Planned on adding role name to Certification namespace, but after discussion with platform team, decided it was best if the role name came from the CertificationExam entity, 