### PR TITLE
Updating TPDM to remove "is queryable field"

### DIFF
--- a/DomainEntity/ApplicantProfile.metaed
+++ b/DomainEntity/ApplicantProfile.metaed
@@ -3,19 +3,15 @@ Domain Entity ApplicantProfile
     shared string ApplicantProfileIdentifier
         documentation "Identifier assigned to a person making formal application for entrance into a program or an open staff position."
         is part of identity
-        is queryable field
     inline common EdFi.Name
         documentation "Full legal name of the person."
         is required
-        is queryable field
     descriptor EdFi.Sex
         documentation "A person's gender."
         is optional
-        is queryable field
     date BirthDate
         documentation "The month, day, and year on which an individual was born."
         is optional
-        is queryable field
     common EdFi.Address
         documentation "The set of elements that describes an address, including the street address, city, state, and ZIP code."
         is optional collection
@@ -25,19 +21,15 @@ Domain Entity ApplicantProfile
     common EdFi.Telephone
         documentation "The 10-digit telephone number, including the area code, for the person."
         is optional collection
-        is queryable field
     common EdFi.ElectronicMail
         documentation "The numbers, letters, and symbols used to identify an electronic mail (e-mail) user within the network to which the individual or organization belongs."
         is optional collection
-        is queryable field
     bool HispanicLatinoEthnicity
         documentation "An indication that the individual traces his or her origin or descent to Mexico, Puerto Rico, Cuba, Central, and South America, and other Spanish cultures, regardless of race. The term, ""Spanish origin,"" can be used in addition to ""Hispanic or Latino""."
         is optional
-        is queryable field
     descriptor EdFi.Race
         documentation "The general racial category which most clearly reflects the individual's recognition of his or her community or with which the individual most identifies. The way this data element is listed, it must allow for multiple entries so that each individual can specify all appropriate races."
         is optional collection
-        is queryable field
     inline common EdFi.Citizenship
         documentation "Contains information relative to citizenship status and its associated probationary documentation."
         is optional
@@ -86,4 +78,3 @@ Domain Entity ApplicantProfile
     shared string EducatorPreparationProgramName
       documentation "The Teacher Preparation Program(s) completed by the teacher."
       is optional collection
-    

--- a/DomainEntity/Application.metaed
+++ b/DomainEntity/Application.metaed
@@ -3,40 +3,33 @@ Domain Entity Application
   shared string ApplicationIdentifier
     documentation "Identifier assigned to the application for a candidate or open staff position."
     is part of identity
-    is queryable field
   domain entity EdFi.EducationOrganization
     documentation "The Education Organization to which the applicant is submitting their application. "
     is part of identity
-    is queryable field
   domain entity ApplicantProfile
     documentation "The profile of the applicant submitting the application."
     is part of identity
-    is queryable field
   date ApplicationDate
     documentation "The month, day, and year the application was submitted."
     is required
-    is queryable field
   descriptor EdFi.Term
     documentation "The intended term of enrollment for which the application is being submitted."
     is optional collection
   descriptor ApplicationStatus
     documentation "Indicates the current status of the application (e.g., received, phone screen, interview, awaiting decision, etc.)."
     is required
-    is queryable field
   bool CurrentEmployee
     documentation "Indicator as to whether the applicant is a current employee of the school district."
     is optional
   descriptor EdFi.AcademicSubject
     documentation "The academic subject for which the application is made."
     is optional
-    is queryable field
   date AcceptedDate
     documentation "The date of acceptance, if offered."
     is optional
   descriptor ApplicationSource
     documentation "Specifies the source for the application (e.g., Job fair, website, referral)."
     is optional
-    is queryable field
   date FirstContactDate
     documentation "Date applicant was first contacted after submitting application."
     is optional
@@ -44,11 +37,9 @@ Domain Entity Application
     documentation "The high need academic subject for the application, if any."
     is optional
     role name HighNeeds
-    is queryable field
   descriptor HireStatus
     documentation "Indicates the current status of the application for hire (e.g., applied, recommended, rejected, exited, offered, hired)."
     is optional
-    is queryable field
   descriptor HiringSource
     documentation "The source for the application (e.g.,job fair, website, referral, etc.)."
     is optional
@@ -64,7 +55,6 @@ Domain Entity Application
   domain entity EdFi.OpenStaffPosition
     documentation "The open staff position associated with the application."
     is optional
-    is queryable field
   domain entity RecruitmentEventAttendance
     documentation "The recuitment event(s) associated with the Application."
     is optional collection

--- a/DomainEntity/FieldworkExperience.metaed
+++ b/DomainEntity/FieldworkExperience.metaed
@@ -3,7 +3,6 @@ Domain Entity FieldworkExperience
     shared string FieldworkIdentifier
         documentation "The unique identifier for the fieldwork experience"
         is part of identity
-        is queryable field
     domain entity EdFi.Student
         documentation "The student associated with the fieldwork experience."
         is part of identity

--- a/DomainEntity/RecruitmentEventAttendance.metaed
+++ b/DomainEntity/RecruitmentEventAttendance.metaed
@@ -3,7 +3,6 @@ Domain Entity RecruitmentEventAttendance
     shared string RecruitmentEventAttendeeIdentifier
         documentation "The identifier for the attendee to a recuitment event."
         is part of identity
-        is queryable field
     bool Applied
         documentation "Indicator of whether the prospect applied for a position."
         is optional
@@ -16,21 +15,18 @@ Domain Entity RecruitmentEventAttendance
     shared string EdFi.ElectronicMailAddress
         documentation "The numbers, letters, and symbols used to identify an electronic mail (e-mail) user within the network to which the individual or organization belongs."
         is required
-        is queryable field
     descriptor Gender
       documentation "The gender with which a person associates."
       is optional
     bool HispanicLatinoEthnicity
         documentation "An indication that the individual traces his or her origin or descent to Mexico, Puerto Rico, Cuba, Central, and South America, and other Spanish cultures, regardless of race. The term, ""Spanish origin,"" can be used in addition to ""Hispanic or Latino""."
         is optional
-        is queryable field
     bool Met
         documentation "Indicator whether the person was met by a representative of the education organization."
         is optional
     inline common EdFi.Name
         documentation "Full legal name of the person."
         is required
-        is queryable field
     shared string Notes
         documentation "Additional notes about the prospect."
         is optional
@@ -46,11 +42,9 @@ Domain Entity RecruitmentEventAttendance
     descriptor EdFi.Race
         documentation "The general racial category which most clearly reflects the individual's recognition of his or her community or with which the individual most identifies. The way this data element is listed, it must allow for multiple entries so that each individual can specify all appropriate races."
         is optional collection
-        is queryable field
     domain entity RecruitmentEvent
         documentation "Reference to event associated with the recruitment process."
         is part of identity
-        is queryable field
     bool Referral
         documentation "Indicator of whether the prospect was a referral."
         is optional
@@ -60,7 +54,6 @@ Domain Entity RecruitmentEventAttendance
     descriptor EdFi.Sex
         documentation "A person's gender."
         is optional
-        is queryable field
     shared string SocialMediaNetworkName
         documentation "The social media network name (e.g., LinkedIn, Twitter, etc.) associated with the SocialMediaUserName."
         is optional
@@ -70,7 +63,6 @@ Domain Entity RecruitmentEventAttendance
     common EdFi.Telephone
         documentation "The 10-digit telephone number, including the area code, for the person."
         is optional collection
-        is queryable field
     common Touchpoint
         documentation "Content associated with different touchpoints with the prospect."
         is optional collection


### PR DESCRIPTION
Updating TPDM Community to remove "is queryable field" as it's been deprecated